### PR TITLE
Update ip_area_code type

### DIFF
--- a/lib/minfraud/response.rb
+++ b/lib/minfraud/response.rb
@@ -7,7 +7,7 @@ module Minfraud
 
     ERROR_CODES = %w( INVALID_LICENSE_KEY IP_REQUIRED LICENSE_REQUIRED COUNTRY_REQUIRED MAX_REQUESTS_REACHED )
     WARNING_CODES = %w( IP_NOT_FOUND COUNTRY_NOT_FOUND CITY_NOT_FOUND CITY_REQUIRED POSTAL_CODE_REQUIRED POSTAL_CODE_NOT_FOUND )
-    INTEGER_ATTRIBUTES = %i(distance queries_remaining ip_accuracy_radius ip_metro_code ip_area_code)
+    INTEGER_ATTRIBUTES = %i(distance queries_remaining ip_accuracy_radius ip_metro_code)
     FLOAT_ATTRIBUTES = %i(ip_latitude ip_longitude score risk_score proxy_score ip_country_conf ip_region_conf ip_city_conf ip_postal_conf)
     BOOLEAN_ATTRIBUTES = %i(country_match high_risk_country anonymous_proxy ip_corporate_proxy free_mail carder_email prepaid city_postal_match
                             ship_city_postal_match bin_match bin_name_match bin_phone_match cust_phone_in_billing_loc ship_forward)


### PR DESCRIPTION
ip_area_code type is no longer an integer, it's a string now. Discovered this when updating kafka schema for the minfraud response.

API doc confirms this http://dev.maxmind.com/minfraud/

@disaacs @ViSovari 