### PR TITLE
Additional host support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ response = transaction.response # http://dev.maxmind.com/minfraud/
 response.parse # parses body to create hash
 ```
 
-To override host choice basically set the `host_choice` attribute on transaction. Available hosts: `:us_east` and `:us_west`
+To override host choice basically set the `host_choice` attribute on transaction. Available hosts: `:us_east`, `:us_west`, and `:eu_west`
 ```ruby
 transaction = Minfraud::Transaction.new do |t|
   # Required fields
@@ -52,6 +52,8 @@ transaction = Minfraud::Transaction.new do |t|
   # ...
 end
 ```
+
+If `host_choice` is not specified or is invalid then the default host of `minfraud-eu-west.maxmind.com` is used.
 
 ### Exception handling
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ transaction = Minfraud::Transaction.new do |t|
 end
 ```
 
-If `host_choice` is not specified or is invalid then the default host of `minfraud-eu-west.maxmind.com` is used.
+If `host_choice` is not specified or is invalid then the default host of `minfraud.maxmind.com` is used.
 
 ### Exception handling
 

--- a/lib/minfraud/minfraud.rb
+++ b/lib/minfraud/minfraud.rb
@@ -12,9 +12,12 @@ module Minfraud
   # Raised if there is an HTTP error on minFraud lookup
   class ConnectionException < StandardError; end
 
+  DEFAULT_HOST = 'https://minfraud.maxmind.com/app/ccv2r'
+
   SERVICE_HOSTS = {
     'us_east' => 'https://minfraud-us-east.maxmind.com/app/ccv2r',
     'us_west' => 'https://minfraud-us-west.maxmind.com/app/ccv2r',
+    'eu_west' => 'https://minfraud-eu-west.maxmind.com/app/ccv2r',
   }
 
   # May be used to configure using common block style:
@@ -68,7 +71,7 @@ module Minfraud
   # MaxMind minFraud API service URI
   # @return [URI::HTTPS] service uri
   def self.uri(host_choice=nil)
-    URI(SERVICE_HOSTS[host_choice] || SERVICE_HOSTS.values.sample)
+    URI(SERVICE_HOSTS[host_choice] || DEFAULT_HOST)
   end
 
   # @return [Boolean] service URI

--- a/spec/minfraud/minfraud_spec.rb
+++ b/spec/minfraud/minfraud_spec.rb
@@ -49,11 +49,12 @@ describe Minfraud do
     it 'returns URI::HTTPS object containing the minFraud service uri' do
       expect(Minfraud.uri('us_east').to_s).to eq('https://minfraud-us-east.maxmind.com/app/ccv2r')
       expect(Minfraud.uri('us_west').to_s).to eq('https://minfraud-us-west.maxmind.com/app/ccv2r')
+      expect(Minfraud.uri('eu_west').to_s).to eq('https://minfraud-eu-west.maxmind.com/app/ccv2r')
     end
 
-    it 'returns URI::HTTPS object containing the minFraud service uri even if the passed choice is not valid' do
-      allow(Minfraud::SERVICE_HOSTS).to receive(:values).and_return(['https://minfraud-us-east.maxmind.com/app/ccv2r'])
-      expect(Minfraud.uri(:foo).to_s).to eq('https://minfraud-us-east.maxmind.com/app/ccv2r')
+    it 'returns URI::HTTPS object containing the minFraud service uri even if the passed choice is missing or is not valid' do
+      expect(Minfraud.uri(:foo).to_s).to eq('https://minfraud.maxmind.com/app/ccv2r')
+      expect(Minfraud.uri.to_s).to eq('https://minfraud.maxmind.com/app/ccv2r')
     end
   end
 


### PR DESCRIPTION
@sunblaze for review

If no `host_choice` is specified, then default will be central `https://minfraud.maxmind.com/app/ccv2r` URI.

Also added the the new `eu_west` host as a choice.