### PR TITLE
Custom host_choice url

### DIFF
--- a/lib/minfraud/minfraud.rb
+++ b/lib/minfraud/minfraud.rb
@@ -71,7 +71,7 @@ module Minfraud
   # MaxMind minFraud API service URI
   # @return [URI::HTTPS] service uri
   def self.uri(host_choice=nil)
-    URI(SERVICE_HOSTS[host_choice] || DEFAULT_HOST)
+    URI(SERVICE_HOSTS[host_choice] || host_choice || DEFAULT_HOST)
   end
 
   # @return [Boolean] service URI

--- a/spec/minfraud/minfraud_spec.rb
+++ b/spec/minfraud/minfraud_spec.rb
@@ -53,8 +53,11 @@ describe Minfraud do
     end
 
     it 'returns URI::HTTPS object containing the minFraud service uri even if the passed choice is missing or is not valid' do
-      expect(Minfraud.uri(:foo).to_s).to eq('https://minfraud.maxmind.com/app/ccv2r')
       expect(Minfraud.uri.to_s).to eq('https://minfraud.maxmind.com/app/ccv2r')
+    end
+
+    it 'throws an exception if the string passed is not one of the presets and is not a valid uri' do
+      expect{Minfraud.uri(:foo).to_s}.to raise_exception(ArgumentError)
     end
   end
 


### PR DESCRIPTION
Support a custom url for the host_choice so we can proxy the request for testing. This also has the side effect that if you misspelled us_east it will try to use it as a URI and fail instead of silently failing and using the default.

@disaacs @ViSovari 