### PR TITLE
Add timeout option

### DIFF
--- a/lib/minfraud/request.rb
+++ b/lib/minfraud/request.rb
@@ -66,6 +66,7 @@ module Minfraud
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      http.open_timeout = http.read_timeout = @transaction.timeout if @transaction.timeout
       request = Net::HTTP::Get.new(uri.request_uri)
       http.request(request)
     end

--- a/lib/minfraud/transaction.rb
+++ b/lib/minfraud/transaction.rb
@@ -33,6 +33,9 @@ module Minfraud
     # Override the host choice for this transaction
     attr_accessor :host_choice
 
+    # Set a custom timeout for both read and opening the connection
+    attr_accessor :timeout
+
     def initialize
       yield self
       unless has_required_attributes?

--- a/lib/minfraud/transaction.rb
+++ b/lib/minfraud/transaction.rb
@@ -75,6 +75,11 @@ module Minfraud
       @response ||= Request.get(self)
     end
 
+    def timeout=(timeout)
+      raise ArgumentError, "Timeout value must be Numeric" unless timeout.is_a?(Numeric)
+      @timeout = timeout
+    end
+
     private
 
     # Ensures the required attributes are present

--- a/spec/minfraud/request_spec.rb
+++ b/spec/minfraud/request_spec.rb
@@ -68,6 +68,24 @@ describe Minfraud::Request do
       expect(Minfraud).to receive(:uri).with('us_east').and_return(us_east_uri)
       Minfraud::Request.new(trans).get
     end
+
+    it 'sets a timeout on the http connection both read and open' do
+      http = double(:http).as_null_object # loose double
+      expect(Net::HTTP).to receive(:new).and_return(http)
+      expect(http).to receive(:read_timeout=).with(3)
+      expect(http).to receive(:open_timeout=).with(3)
+
+      trans = Minfraud::Transaction.new do |t|
+        t.ip = '1'
+        t.city = '2'
+        t.state = '3'
+        t.postal = '4'
+        t.country = '5'
+        t.txn_id = '6'
+        t.timeout = 3
+      end
+      Minfraud::Request.new(trans).get
+    end
   end
 
 end

--- a/spec/minfraud/transaction_spec.rb
+++ b/spec/minfraud/transaction_spec.rb
@@ -144,4 +144,19 @@ describe Minfraud::Transaction do
 
   end
 
+  describe "#timeout=" do
+    it 'raises an ArgumentError if a numeric value is not provided' do
+      transaction = Minfraud::Transaction.new do |t|
+        t.ip = 'ip'
+        t.city = 'city'
+        t.state = 'state'
+        t.postal = 'postal'
+        t.country = 'country'
+        t.email = 'hughjass@example.com'
+        t.txn_id = 'Order-1'
+      end
+      expect { transaction.timeout = "2.0" }.to raise_exception(ArgumentError, /Timeout value must be Numeric/)
+    end
+  end
+
 end


### PR DESCRIPTION
Added an optional timeout attribute to the transaction that's used by the gem to set a timeout on the http request both for read and opening a connection.

@disaacs @ViSovari 