### PR TITLE
Less restrictions of required attributes

### DIFF
--- a/lib/minfraud/transaction.rb
+++ b/lib/minfraud/transaction.rb
@@ -85,7 +85,7 @@ module Minfraud
     # Ensures the required attributes are present
     # @return [Boolean]
     def has_required_attributes?
-      ip and city and state and postal and country and txn_id
+      ip && txn_id
     end
 
     # Validates the types of the attributes


### PR DESCRIPTION
city, state, postal, country and txn_id are highly recommended but not required. Let's stop throwing an exception when they're missing.

@disaacs @omosola 