### PR TITLE
Allow nil billing address

### DIFF
--- a/lib/minfraud/transaction.rb
+++ b/lib/minfraud/transaction.rb
@@ -100,8 +100,8 @@ module Minfraud
     # @return [nil, TransactionError]
     def validate_string(attr_name)
       attribute = self.send(attr_name)
-      unless attribute.instance_of?(String)
-        raise TransactionError, "Transaction.#{attr_name} must me a string"
+      if attribute && !attribute.instance_of?(String)
+        raise TransactionError, "Transaction.#{attr_name} must be a string"
       end
     end
 

--- a/spec/minfraud/transaction_spec.rb
+++ b/spec/minfraud/transaction_spec.rb
@@ -26,7 +26,14 @@ describe Minfraud::Transaction do
           t.txn_id = ''
         end
       end
-      expect { transaction.call }.to raise_exception(Minfraud::TransactionError, /city must me a string/)
+      expect { transaction.call }.to raise_exception(Minfraud::TransactionError, /city must be a string/)
+    end
+
+    it 'does not raise an exception if billing address is left nil' do
+      Minfraud::Transaction.new do |t|
+        t.ip = '127.0.0.1'
+        t.txn_id = 'Order-1-1'
+      end
     end
   end
 


### PR DESCRIPTION
Exceptions were still being thrown if the billing address was not provided. Wrote a test and fixed the string assertion

@disaacs @omosola 