### PR TITLE
split method has argument to only splits into two parts

### DIFF
--- a/lib/minfraud/response.rb
+++ b/lib/minfraud/response.rb
@@ -41,7 +41,7 @@ module Minfraud
     # @param body [String] raw response body string
     def decode_body
       raise ConnectionException, "The minFraud service responded with http error #{@raw.class}" unless @raw.is_a?(Net::HTTPSuccess)
-      transform_keys(Hash[@raw.body.force_encoding("ISO-8859-1").split(';').map { |e| e.split('=') }]).tap do |body|
+      transform_keys(Hash[@raw.body.force_encoding("ISO-8859-1").split(';').map { |e| e.split('=', 2) }]).tap do |body|
         raise ResponseError, "Error message from minFraud: #{body[:err]}" if ERROR_CODES.include?(body[:err])
       end
     end

--- a/spec/minfraud/response_spec.rb
+++ b/spec/minfraud/response_spec.rb
@@ -5,6 +5,7 @@ describe Minfraud::Response do
   let(:test_response_double) { double(Net::HTTPOK, body: 'distance=17034;ip_latitude=-27.0000', is_a?: true, code: 200) }
   let(:boolean_test_response_double) { double(Net::HTTPOK, body: 'countryMatch=Yes;highRiskCountry=No;binMatch=NotFound;binNameMatch=NA', is_a?: true, code: 200) }
   let(:latin1_response_double) { double(Net::HTTPOK, body: 'ip_city=Montr\xE9al'.force_encoding("ASCII-8BIT"), is_a?: true, code: 200) }
+  let(:multiple_equals_response_double) { double(Net::HTTPOK, body: 'maxmindID=ANK4C13A;ip_asnum=S44700 == Upstreams =======================================', is_a?: true, code: 200) }
   let(:warning_response_double) { double(Net::HTTPOK, body: 'err=COUNTRY_NOT_FOUND', is_a?: true, code: 200) }
   let(:error_response_double) { double(Net::HTTPOK, body: 'err=INVALID_LICENSE_KEY', is_a?: true, code: 200) }
   let(:server_error_response_double) { double(Net::HTTPRequestTimeOut, code: 408) }
@@ -15,6 +16,7 @@ describe Minfraud::Response do
     subject(:test_response) { Minfraud::Response.new(test_response_double).tap {|r| r.parse} }
     subject(:boolean_test_response) { Minfraud::Response.new(boolean_test_response_double).tap {|r| r.parse} }
     subject(:latin1_response) { Minfraud::Response.new(latin1_response_double).tap {|r| r.parse} }
+    subject(:multiple_equals_response) { Minfraud::Response.new(multiple_equals_response_double).tap {|r| r.parse} }
     subject(:server_error_response) { Minfraud::Response.new(server_error_response_double) }
     subject(:error_response) { Minfraud::Response.new(error_response_double) }
     subject(:warning_response) { Minfraud::Response.new(warning_response_double) }
@@ -59,6 +61,11 @@ describe Minfraud::Response do
     it 'parse converts minfraud ISO-8859-1 output to UTF-8 automatically' do
       expect(latin1_response.ip_city.encoding).to eq(Encoding.find("UTF-8"))
       expect(latin1_response.ip_city).to eq('Montr\xE9al'.encode("UTF-8"))
+    end
+
+    it 'successfully parses input that has multiple equals operators between two semicolons' do
+      expect(multiple_equals_response.maxmind_id).to eq('ANK4C13A')
+      expect(multiple_equals_response.ip_asnum).to eq('S44700 == Upstreams =======================================')
     end
   end
 


### PR DESCRIPTION
This fixes Shopify/Bladerunner issue #308. Logging the body of the raw response objects that trigger transaction ArgumentErrors has show that the issue is that sometimes there is more than one '=' character between two ';' characters. By passing an extra argument to the split method, the sections between ';' will always be split into two from now on, which will allow them to be converted to hashes without causing errors. 
review: @disaacs @sunblaze @berkcaputcu 
