### PR TITLE
remove empty strings from array in parse method

### DIFF
--- a/lib/minfraud/response.rb
+++ b/lib/minfraud/response.rb
@@ -41,7 +41,7 @@ module Minfraud
     # @param body [String] raw response body string
     def decode_body
       raise ConnectionException, "The minFraud service responded with http error #{@raw.class}" unless @raw.is_a?(Net::HTTPSuccess)
-      transform_keys(Hash[@raw.body.force_encoding("ISO-8859-1").split(';').map { |e| e.split('=', 2) }]).tap do |body|
+      transform_keys(Hash[(@raw.body.force_encoding("ISO-8859-1").split(';').reject! { |e| e.empty? }).map { |e| e.split('=', 2) }]).tap do |body|
         raise ResponseError, "Error message from minFraud: #{body[:err]}" if ERROR_CODES.include?(body[:err])
       end
     end


### PR DESCRIPTION
This PR addresses issue Shopify/BladeRunner#208. An ArgumentError in transaction/analysis was being caused by the presence of empty strings in the string array derived from the raw response object. This was caused by an ip_asnum number that contained multiple semi-colons in it, and thus was not being split up properly (since the raw response is initially split up by semi-colons). To fix this issue, after the raw response is split into an array of strings, this PR now removes any empty strings before further processing.
@disaacs @sunblaze @damianp-shopify