### PR TITLE
remove bang in response parsing reject method

### DIFF
--- a/lib/minfraud/response.rb
+++ b/lib/minfraud/response.rb
@@ -41,7 +41,7 @@ module Minfraud
     # @param body [String] raw response body string
     def decode_body
       raise ConnectionException, "The minFraud service responded with http error #{@raw.class}" unless @raw.is_a?(Net::HTTPSuccess)
-      transform_keys(Hash[(@raw.body.force_encoding("ISO-8859-1").split(';').reject! { |e| e.empty? }).map { |e| e.split('=', 2) }]).tap do |body|
+      transform_keys(Hash[(@raw.body.force_encoding("ISO-8859-1").split(';').reject { |e| e.empty? }).map { |e| e.split('=', 2) }]).tap do |body|
         raise ResponseError, "Error message from minFraud: #{body[:err]}" if ERROR_CODES.include?(body[:err])
       end
     end


### PR DESCRIPTION
Using bang with the reject method will return nil if no changes are made. However, most of the time, no changes are made, so this would cause errors. As a result, I've removed the bang from the reject method to make sure this method works well both when changes are and aren't made to the response object using the reject method.
@disaacs 