### PR TITLE
Add the IP_NOT_FOUND error code

### DIFF
--- a/lib/minfraud/response.rb
+++ b/lib/minfraud/response.rb
@@ -5,7 +5,7 @@ module Minfraud
   # field from minFraud, you can get it with `#ip_corporate_proxy`.
   class Response
 
-    ERROR_CODES = %w( INVALID_LICENSE_KEY IP_REQUIRED LICENSE_REQUIRED COUNTRY_REQUIRED MAX_REQUESTS_REACHED )
+    ERROR_CODES = %w( INVALID_LICENSE_KEY IP_REQUIRED IP_NOT_FOUND LICENSE_REQUIRED COUNTRY_REQUIRED MAX_REQUESTS_REACHED )
     WARNING_CODES = %w( IP_NOT_FOUND COUNTRY_NOT_FOUND CITY_NOT_FOUND CITY_REQUIRED POSTAL_CODE_REQUIRED POSTAL_CODE_NOT_FOUND )
     INTEGER_ATTRIBUTES = %i(distance queries_remaining ip_accuracy_radius ip_metro_code)
     FLOAT_ATTRIBUTES = %i(ip_latitude ip_longitude score risk_score proxy_score ip_country_conf ip_region_conf ip_city_conf ip_postal_conf)


### PR DESCRIPTION
IP_NOT_FOUND is a possible error code in the minFraud legacy API: https://dev.maxmind.com/minfraud/minfraud-legacy/#Error_Reporting

It should be included in the list of possible codes, so we correctly classify these errors.

Resolves https://github.com/Shopify/BladeRunner/issues/1613