### PR TITLE
Reverts #16 Add the IP_NOT_FOUND error code

### DIFF
--- a/lib/minfraud/response.rb
+++ b/lib/minfraud/response.rb
@@ -5,7 +5,7 @@ module Minfraud
   # field from minFraud, you can get it with `#ip_corporate_proxy`.
   class Response
 
-    ERROR_CODES = %w( INVALID_LICENSE_KEY IP_REQUIRED IP_NOT_FOUND LICENSE_REQUIRED COUNTRY_REQUIRED MAX_REQUESTS_REACHED )
+    ERROR_CODES = %w( INVALID_LICENSE_KEY IP_REQUIRED LICENSE_REQUIRED COUNTRY_REQUIRED MAX_REQUESTS_REACHED )
     WARNING_CODES = %w( IP_NOT_FOUND COUNTRY_NOT_FOUND CITY_NOT_FOUND CITY_REQUIRED POSTAL_CODE_REQUIRED POSTAL_CODE_NOT_FOUND )
     INTEGER_ATTRIBUTES = %i(distance queries_remaining ip_accuracy_radius ip_metro_code)
     FLOAT_ATTRIBUTES = %i(ip_latitude ip_longitude score risk_score proxy_score ip_country_conf ip_region_conf ip_city_conf ip_postal_conf)


### PR DESCRIPTION
Reverts #16 

This Pr was added as a part of the solution for [this issue in bladerunner](https://github.com/Shopify/BladeRunner/issues/1613).           

However this change was incorrect and it needs to be reverted because based on the conversation of @phsurette  from Maxmind It turns out that the IP_NOT_FOUND 'errors' from minfraud should be treated as warnings instead of errors([comment](https://github.com/Shopify/minfraud-ruby/pull/16#issuecomment-524893416)).        

We already have the IP_NOT_FOUND in the [warning codes](https://github.com/Shopify/minfraud-ruby/blob/bbaf6336d0ac50d9ea4b5392d400505643844b2b/lib/minfraud/response.rb#L9) so this pr just remove it from the error codes.

