### PR TITLE
Update dev.yml to remove OpenSSL

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -4,7 +4,6 @@ type: ruby
 
 up:
   - homebrew:
-    - openssl
   - ruby: 2.5.3
   - bundler
 


### PR DESCRIPTION
Specifying openssl in dev.yml's homebrew section is deprecated since OpenSSL 1.1 is always installed. Removing it fixes dev and is a prerequisite for further development on this gem.

@Shopify/riskeng 