### PR TITLE
Set open and read timeout separately

### DIFF
--- a/lib/minfraud/request.rb
+++ b/lib/minfraud/request.rb
@@ -68,6 +68,8 @@ module Minfraud
       http.use_ssl = true
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
       http.open_timeout = http.read_timeout = @transaction.timeout if @transaction.timeout
+      http.open_timeout = @transaction.open_timeout if @transaction.open_timeout
+      http.read_timeout = @transaction.read_timeout if @transaction.read_timeout
       request = Net::HTTP::Get.new(uri.request_uri)
       http.request(request)
     end

--- a/lib/minfraud/transaction.rb
+++ b/lib/minfraud/transaction.rb
@@ -36,6 +36,9 @@ module Minfraud
     # Set a custom timeout for both read and opening the connection
     attr_accessor :timeout
 
+    # Connection timeout and read timeout
+    attr_accessor :open_timeout, :read_timeout
+
     def initialize
       yield self
       unless has_required_attributes?
@@ -78,6 +81,16 @@ module Minfraud
     def timeout=(timeout)
       raise ArgumentError, "Timeout value must be Numeric" unless timeout.is_a?(Numeric)
       @timeout = timeout
+    end
+
+    def open_timeout=(timeout)
+      raise ArgumentError, "Open timeout value must be Numeric" unless timeout.is_a?(Numeric)
+      @open_timeout = timeout
+    end
+
+    def read_timeout=(timeout)
+      raise ArgumentError, "Read timeout value must be Numeric" unless timeout.is_a?(Numeric)
+      @read_timeout = timeout
     end
 
     private

--- a/spec/minfraud/request_spec.rb
+++ b/spec/minfraud/request_spec.rb
@@ -69,7 +69,7 @@ describe Minfraud::Request do
       Minfraud::Request.new(trans).get
     end
 
-    it 'sets a timeout on the http connection both read and open' do
+    it 'sets a timeout on the http connection both read and open when given only a default timeout' do
       http = double(:http).as_null_object # loose double
       expect(Net::HTTP).to receive(:new).and_return(http)
       expect(http).to receive(:read_timeout=).with(3)
@@ -83,6 +83,26 @@ describe Minfraud::Request do
         t.country = '5'
         t.txn_id = '6'
         t.timeout = 3
+      end
+      Minfraud::Request.new(trans).get
+    end
+
+    it 'sets a timeout on the http connection both read and open when given each timeout' do
+      http = double(:http).as_null_object # loose double
+      expect(Net::HTTP).to receive(:new).and_return(http)
+      expect(http).to receive(:read_timeout=).with(4)
+      expect(http).to receive(:open_timeout=).with(3)
+
+      trans = Minfraud::Transaction.new do |t|
+        t.ip = '1'
+        t.city = '2'
+        t.state = '3'
+        t.postal = '4'
+        t.country = '5'
+        t.txn_id = '6'
+        t.timeout = 2
+        t.open_timeout = 3
+        t.read_timeout = 4
       end
       Minfraud::Request.new(trans).get
     end

--- a/spec/minfraud/transaction_spec.rb
+++ b/spec/minfraud/transaction_spec.rb
@@ -166,4 +166,40 @@ describe Minfraud::Transaction do
     end
   end
 
+  describe "#open_timeout=" do
+    it 'raises an ArgumentError if a numeric value is not provided' do
+      transaction = Minfraud::Transaction.new do |t|
+        t.ip = 'ip'
+        t.city = 'city'
+        t.state = 'state'
+        t.postal = 'postal'
+        t.country = 'country'
+        t.email = 'hughjass@example.com'
+        t.txn_id = 'Order-1'
+      end
+      expect { transaction.open_timeout = "1.0" }.to raise_exception(
+        ArgumentError,
+        /Open timeout value must be Numeric/
+      )
+    end
+  end
+
+  describe "#read_timeout=" do
+    it 'raises an ArgumentError if a numeric value is not provided' do
+      transaction = Minfraud::Transaction.new do |t|
+        t.ip = 'ip'
+        t.city = 'city'
+        t.state = 'state'
+        t.postal = 'postal'
+        t.country = 'country'
+        t.email = 'hughjass@example.com'
+        t.txn_id = 'Order-1'
+      end
+      expect { transaction.read_timeout = "3.0" }.to raise_exception(
+        ArgumentError,
+        /Read timeout value must be Numeric/
+      )
+    end
+  end
+
 end


### PR DESCRIPTION
Open timeouts specify how long we wait while establishing a connection, while read timeouts govern the time we wait for a response. These are additive and often should be different values.

Instead of using a one timeout for both underlying HTTP timeouts, we can specify them individually.