### PR TITLE
Improve validation and refactor client

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 Compatible with [minFraud](http://www.maxmind.com/en/ccv_overview) Legacy API
 
-[minFraud API documentation](https://dev.maxmind.com/minfraud/minfraud-legacy/)  
+[minFraud Legacy API documentation](https://dev.maxmind.com/minfraud/minfraud-legacy/)  
 
-## Usage
+### Example Usage
 
 ```ruby
+# Create a client to handle requests for a specific host
 minfraud_client = Minfraud::MinfraudClient.new(
   # Optional fields to customize connection
   host_choice: 'us_east',
@@ -17,29 +18,66 @@ minfraud_client = Minfraud::MinfraudClient.new(
   pool_size: 10
 )
 
+# Create a transaction with attributes to send
+# The transaction will be immutable after creation
 transaction = Minfraud::Transaction.new do |t|
   # Required fields
-  # Other fields listed later in documentation are optional
   t.ip = '1.2.3.4'
+  t.txn_id = 'Order-1'
+  t.license_key = 'minfraud-license-key'
+  # Other fields are optional
   t.city = 'richmond'
   t.state = 'virginia'
   t.postal = '12345'
   t.country = 'US' # http://en.wikipedia.org/wiki/ISO_3166-1
-  t.txn_id = 'Order-1'
-  t.license_key = 'minfraud-license-key'
   # ...
 end
 
+# Send the transaction to minFraud and retrieve the parsed response
+# The response will be immutable
 response = minfraud_client.send_transaction(
   transaction: transaction,
-  # Optional field to customize connection
+  # Optional url to customize the request endpoint
+  # Default value is `/app/ccv2r`
   url: '/app/ccv2r'
 )
 
-response.parse # parses body to create hash
+# All attributes from minFraud's response will be available on the response object
+# as a snake-cased attribute. For example, if you want the `proxyScore` field
+# from minFraud, you can get it with `#proxy_score`.
 
-response.dig(:risk_score)
+response.risk_score
 # => 3.48
+
+response.queries_remaining
+# => 1000
+
+# A warning may be present in the `#err` attribute
+response.err
+# => nil
+
+# The attributes can also be retrieved as a Hash
+# Note that this is a frozen Hash
+response_hash = response.body # frozen Hash
+response_hash = response.body.dup # mutable duplicate of Hash
+
+response[:risk_score]
+response[:queries_remaining]
+response[:err]
+```
+
+#### Customizing the response
+
+The `Minfraud::Response` is frozen after initialization, but sometimes attributes may need to be added or modified.
+
+This customization can be done via a block on `Minfraud::MinfraudClient#send_transaction`:
+
+```ruby
+response = minfraud_client.send_transaction(transaction: transaction) do |resp|
+  # resp is the Hash of attributes on the response
+  resp[:new_attribute] = some_modification_of(resp[:existing_attribute])
+  resp[:another_existing_attribute] = 'new_value'
+end
 ```
 
 ### Exception handling
@@ -47,48 +85,91 @@ response.dig(:risk_score)
 There are three different exceptions that this gem may raise. Please be prepared to handle them:
 
 ```ruby
-# Raised if a transaction is invalid
+# Raised by Minfraud::Transaction.new if transaction parameters are invalid
 class TransactionError < ArgumentError; end
 
-# Raised if minFraud returns an error
+# Raised by Minfraud::MinfraudClient.send_transaction if minFraud returns an error
 class ResponseError < StandardError; end
 
-# Raised if there is an HTTP error on minFraud lookup
+# Raised by Minfraud::MinfraudClient.send_transaction if there was a connection error
 class ConnectionException < StandardError; end
 ```
+
+### Warnings
+
+If there was a warning with the request, the warning code will be present in the `#err` attribute
+on the response object. No errors will be raised and a `MinfraudClient::Response` will be returned.
+
+The possible warning codes are:
+- `IP_NOT_FOUND`
+  - This is an error from minFraud's perspective - it is returned if the IP address is not valid,
+    if it is not public, or if it is not in minFraud's GeoIP database.
+  - The client treats this as a warning instead of an error to allow a `risk_score` to be retrieved.
+- `COUNTRY_NOT_FOUND`
+- `CITY_NOT_FOUND`
+- `CITY_REQUIRED`
+- `INVALID_EMAIL_MD5`
+- `POSTAL_CODE_REQUIRED`
+- `POSTAL_CODE_NOT_FOUND`
 
 ### Transaction fields
 
 #### Required
 
-| name          | type (length)         | example                             | description |
-| ------------- | --------------------- | ----------------------------------- | ----------- |
-| ip            | string                | `t.ip = '1.2.3.4'`                  | Customer IP address |
-| city          | string                | `t.city = 'new york'`               | Customer city |
-| state         | string                | `t.state = 'new york'`              | Customer state/province/region |
-| postal        | string                | `t.postal = '10014'`                | Customer zip/postal code |
-| country       | string                | `t.country = 'US'`                  | Customer ISO 3166-1 country code |
-| txn_id        | string                | `t.txn_id = 'Order-1'`              | Transaction/order id
+| name          | type   | example                             | description |
+| ------------- | ------ | ----------------------------------- | ----------- |
+| ip            | string | `t.ip = '1.2.3.4'`                  | Customer IP address  |
+| txn_id        | string | `t.txn_id = 'Order-1'`              | Transaction/order id |
+| license_key   | string | `t.license_key = 'default_license'` | MaxMind license key  |
 
 #### Optional
 
-| name               | type (length)      | description |
-| ------------------ | ------------------ | ----------- |
-| ship_addr          | string             | |
-| ship_city          | string             | |
-| ship_state         | string             | |
-| ship_postal        | string             | |
-| ship_country       | string             | |
-| email              | string             | We will hash the email for you |
-| phone              | string             | Any format acceptable |
-| bin                | string             | CC bin number (first 6 digits) |
-| session_id         | string             | Used for linking transactions |
-| user_agent         | string             | Used for linking transactions |
-| accept_language    | string             | Used for linking transactions |
-| amount             | string             | Transaction amount |
-| currency           | string             | ISO 4217 currency code |
-| txn_type           | string             | creditcard/debitcard/paypal/google/other/lead/survey/sitereg |
-| avs_result         | string             | Standard AVS response code |
-| cvv_result         | string             | Y/N |
-| requested_type     | string             | standard/premium |
-| forwarded_ip       | string             | The end user’s IP address, as forwarded by a transparent proxy |
+| name               | type    | description |
+| ------------------ | ------- | ----------- |
+| city               | string  | Billing address city |
+| state              | string  | Billing address region/state |
+| postal             | string  | Billing address postal (zip) code |
+| country            | string  | Billing address country as full country name or as an [ISO 3166](https://en.wikipedia.org/wiki/ISO_3166) code |
+| ship_addr          | string  | Shipping street address |
+| ship_city          | string  | Shipping address city |
+| ship_state         | string  | Shipping address region/state |
+| ship_postal        | string  | Shipping address postal (zip) code |
+| ship_country       | string  | Shipping address country |
+| email              | string  | Customer email - will be hashed using MD5 before sending |
+| phone              | string  | Any format acceptable |
+| bin                | string  | CC bin number (first 6 digits) |
+| user_agent         | string  | Used for linking transactions |
+| accept_language    | string  | Used for linking transactions |
+| amount             | numeric | Transaction amount - A string representation of a numeric is also accepted |
+| currency           | string  | [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) currency code |
+| txn_type           | string  | `creditcard`/`debitcard`/`paypal`/`google`/`other`/`lead`/`survey`/`sitereg` |
+| shop_id            | string  | Shop ID - If the input is not a string, the client will convert it using `.to_s` |
+| avs_result         | string  | Standard AVS response code |
+| cvv_result         | string  | CVV code represented as a single letter |
+| requested_type     | string  | `standard`/`premium` |
+
+### Connection Details
+
+The HTTP client used by `Minfraud::MinfraudClient` is [Faraday](https://github.com/lostisland/faraday), which allows for
+different middleware and adapters to customize how requests are sent.
+
+We are using the [net-http-persistent](https://github.com/drbrain/net-http-persistent) adapter that keeps connections
+alive between requests. Connections are shared in a connection pool, making the client more robust to network failures
+and also speeds up request times.
+
+`Minfraud::MinfraudClient` can be customized with the following parameters upon initialization:
+
+| parameter     | type    | default value                  | description |
+| ------------- | ------- | ------------------------------ | ----------- |
+| host_choice   | string  | `https://minfraud.maxmind.com` | Base URL to send requests to. `us_east`/`us_west`/`eu_west` can be used to select pre-defined hosts. A custom URL can also be passed in. |
+| open_timeout  | integer | `1`                            | Seconds to wait for a connection to be opened |
+| idle_timeout  | integer | `5`                            | Seconds before automatically be resetting an unused connection |
+| read_timeout  | integer | `5`                            | Seconds to wait until reading one block |
+| write_timeout | integer | `5`                            | Seconds to wait until writing one block |
+| pool_size     | integer | `10`                           | Maximum number of connections allowed at once |
+
+### Immutability
+
+`Minfraud::Transaction` and `Minfraud::Response` are both made immutable (frozen) after initialization.
+
+This allows transactions and responses to be used as value objects with a guarantee that their attributes do not change.

--- a/lib/minfraud/minfraud.rb
+++ b/lib/minfraud/minfraud.rb
@@ -9,14 +9,14 @@ module Minfraud
   # Raised if there is an HTTP error on minFraud lookup
   class ConnectionException < StandardError; end
 
-  DEFAULT_HOST = 'https://minfraud.maxmind.com'
+  DEFAULT_HOST = 'https://minfraud.maxmind.com'.freeze
 
-  DEFAULT_API = '/app/ccv2r'
+  DEFAULT_API = '/app/ccv2r'.freeze
 
   SERVICE_HOSTS = {
     'us_east' => 'https://minfraud-us-east.maxmind.com',
     'us_west' => 'https://minfraud-us-west.maxmind.com',
     'eu_west' => 'https://minfraud-eu-west.maxmind.com',
-  }
+  }.freeze
 
 end

--- a/minfraud-ruby.gemspec
+++ b/minfraud-ruby.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "yard"
   spec.add_development_dependency "webmock"
+  spec.add_development_dependency "bigdecimal"
 end

--- a/spec/minfraud/minfraud_client_spec.rb
+++ b/spec/minfraud/minfraud_client_spec.rb
@@ -2,19 +2,31 @@ require 'spec_helper'
 require 'webmock/rspec'
 
 describe Minfraud::MinfraudClient do
-  subject(:minfraud_client) {
-    Minfraud::MinfraudClient.new(host_choice: base_url)
+  subject(:minfraud_client) { Minfraud::MinfraudClient.new }
+  subject(:minfraud_client_east) { Minfraud::MinfraudClient.new(host_choice: 'us_east') }
+  let(:transaction) {
+    Minfraud::Transaction.new do |t|
+      t.ip = '127.0.0.1'
+      t.txn_id = 'Order-1-1'
+      t.license_key = 'test_license'
+    end
   }
-  let(:transaction) { double(Minfraud::Transaction, attributes: {}) }
-  let(:success_response) { double(Minfraud::Response, code: 200, body: '') }
+  let(:success_response) { double(Minfraud::Response, body: '') }
 
-  describe '.new' do
+  describe 'Minfraud::MinfraudClient.new' do
     it 'creates a new Faraday Connection' do
       expect(minfraud_client.instance_variable_get(:@http_client)).to be_instance_of(Faraday::Connection)
     end
   end
 
-  describe '#send_transaction' do
+  describe 'Minfraud::MinfraudClient.FIELD_MAP' do
+    it 'matches Minfraud::Transaction.ATTRIBUTES' do
+      expect(Minfraud::MinfraudClient.const_get(:FIELD_MAP).keys)
+        .to match_array(Minfraud::Transaction.const_get(:ATTRIBUTES))
+    end
+  end
+
+  describe 'Minfraud::MinfraudClient#send_transaction' do
     it 'sends appropriately encoded transaction data to minFraud service' do
       allow(Minfraud::Response).to receive(:new).and_return(success_response)
       stub_request(:get, request_url)
@@ -31,7 +43,7 @@ describe Minfraud::MinfraudClient do
         t.license_key = '7'
       end
 
-      minfraud_client.send_transaction(transaction: transaction, url: endpoint_url)
+      minfraud_client.send_transaction(transaction: transaction)
 
       expect(a_request(:get, request_url).with(
         query: hash_including({
@@ -52,23 +64,25 @@ describe Minfraud::MinfraudClient do
         .with(query: hash_including({})) # ignores query parameters
         .to_return(status: 200, body: '')
 
-      minfraud_client.send_transaction(transaction: transaction, url: endpoint_url)
+      minfraud_client.send_transaction(transaction: transaction)
 
       expect(a_request(:get, request_url).with(
-        headers: { 'Connection' => 'keep-alive' }
+        headers: { 'Connection' => 'keep-alive' },
+        query: hash_including({}) # ignores query parameters
       )).to have_been_made
     end
 
     it 'sends request to the right service host' do
-      minfraud_client = Minfraud::MinfraudClient.new(host_choice: 'us_east')
       allow(Minfraud::Response).to receive(:new).and_return(success_response)
-      stub_request(:get, 'https://minfraud-us-east.maxmind.com/app/ccv2r')
+      stub_request(:get, request_url_east)
         .with(query: hash_including({})) # ignores query parameters
         .to_return(status: 200, body: '')
 
-      minfraud_client.send_transaction(transaction: transaction, url: endpoint_url)
+      minfraud_client_east.send_transaction(transaction: transaction)
 
-      expect(a_request(:get, 'https://minfraud-us-east.maxmind.com/app/ccv2r')).to have_been_made
+      expect(a_request(:get, request_url_east).with(
+        query: hash_including({}) # ignores query parameters
+      )).to have_been_made
     end
 
     it 'raises a ConnectionException if there is an HTTP error' do
@@ -78,27 +92,33 @@ describe Minfraud::MinfraudClient do
         .to_raise(Errno::ECONNREFUSED)
 
       expect {
-        minfraud_client.send_transaction(transaction: transaction, url: endpoint_url)
+        minfraud_client.send_transaction(transaction: transaction)
       }.to raise_error(Minfraud::ConnectionException)
     end
 
     it 'creates Response object out of raw response' do
       expect(minfraud_client.instance_variable_get(:@http_client)).to receive(:get)
       expect(Minfraud::Response).to receive(:new).and_return(success_response)
-      minfraud_client.send_transaction(transaction: transaction, url: endpoint_url)
+      minfraud_client.send_transaction(transaction: transaction)
     end
-  end
 
-  def base_url
-    'https://minfraud.maxmind.com'
-  end
-
-  def endpoint_url
-    '/app/ccv2r'
+    it 'creates passes a block to modify the Response' do
+      expect(minfraud_client.instance_variable_get(:@http_client)).to receive(:get)
+      expect_any_instance_of(Minfraud::Response).to receive(:decode_body).and_return({})
+      response = minfraud_client.send_transaction(transaction: transaction) do |resp|
+        resp[:absurd] = 'not_absurd'
+      end
+      expect(response.absurd).to eq('not_absurd')
+      expect(response.something_else).to be_nil
+    end
   end
 
   def request_url
     'https://minfraud.maxmind.com/app/ccv2r'
+  end
+
+  def request_url_east
+    'https://minfraud-us-east.maxmind.com/app/ccv2r'
   end
 
 end

--- a/spec/minfraud/transaction_spec.rb
+++ b/spec/minfraud/transaction_spec.rb
@@ -1,12 +1,14 @@
 require 'spec_helper'
+require 'bigdecimal'
 
 describe Minfraud::Transaction do
 
-  describe '.new' do
+  describe 'Minfraud::Transaction.new' do
     it 'yields the current instance module' do
       Minfraud::Transaction.new do |t|
-        allow(t).to receive(:has_required_attributes?).and_return(true)
-        allow(t).to receive(:validate_attributes).and_return(nil)
+        t.ip = '127.0.0.1'
+        t.txn_id = 'Order-1-1'
+        t.license_key = 'test_license'
         expect(t).to be_an_instance_of(Minfraud::Transaction)
       end
     end
@@ -15,26 +17,76 @@ describe Minfraud::Transaction do
       expect { Minfraud::Transaction.new { |c| true } }.to raise_exception(Minfraud::TransactionError, /required/)
     end
 
-    it 'raises an exception if attributes are invalid' do
+    it 'raises an exception if string attributes are invalid' do
       transaction = lambda do
         Minfraud::Transaction.new do |t|
-          t.ip = ''
+          t.ip = '127.0.0.1'
+          t.txn_id = 'Order-1-1'
+          t.license_key = 'test_license'
           t.city = 2
-          t.state = ''
-          t.postal = ''
-          t.country = ''
-          t.txn_id = ''
-          t.license_key = ''
+          t.amount = 27.04
+          t.state = 'test_state'
         end
       end
       expect { transaction.call }.to raise_exception(Minfraud::TransactionError, /city must be a string/)
+    end
+
+    it 'raises an exception if numeric attributes are invalid' do
+      transaction = lambda do
+        Minfraud::Transaction.new do |t|
+          t.ip = '127.0.0.1'
+          t.txn_id = 'Order-1-1'
+          t.license_key = 'test_license'
+          t.amount = 'not_a_number'
+          t.state = 'test_state'
+        end
+      end
+      expect { transaction.call }.to raise_exception(Minfraud::TransactionError, /amount must be a number/)
+    end
+
+    it 'accepts strings as numbers' do
+      Minfraud::Transaction.new do |t|
+        t.ip = '127.0.0.1'
+        t.txn_id = 'Order-1-1'
+        t.license_key = 'test_license'
+        t.amount = '27.04'
+      end
+    end
+
+    it 'accepts BigDecimal inputs for numbers' do
+      Minfraud::Transaction.new do |t|
+        t.ip = '127.0.0.1'
+        t.txn_id = 'Order-1-1'
+        t.license_key = 'test_license'
+        t.amount = BigDecimal('27.04')
+      end
+    end
+
+    it 'creates the Transaction properly' do
+      Minfraud::Transaction.new do |t|
+        t.ip = '127.0.0.1'
+        t.txn_id = 'Order-1-1'
+        t.license_key = 'test_license'
+        t.city = 'test_city'
+        t.cvv_result = 'M'
+        t.amount = 27.04
+      end
+    end
+
+    it 'returns an immutable Transaction' do
+      transaction = Minfraud::Transaction.new do |t|
+        t.ip = '127.0.0.1'
+        t.txn_id = 'Order-1-1'
+        t.license_key = 'test_license'
+      end
+      expect(transaction).to be_frozen
     end
 
     it 'does not raise an exception if billing address is left nil' do
       Minfraud::Transaction.new do |t|
         t.ip = '127.0.0.1'
         t.txn_id = 'Order-1-1'
-        t.license_key = ''
+        t.license_key = 'test_license'
       end
     end
 
@@ -47,35 +99,90 @@ describe Minfraud::Transaction do
       end
       expect { transaction.call }.to raise_exception(Minfraud::TransactionError, /required/)
     end
+
+    it 'raises an exception if license key is left empty' do
+      transaction = lambda do
+        Minfraud::Transaction.new do |t|
+          t.ip = '127.0.0.1'
+          t.txn_id = 'Order-1-1'
+          t.license_key = ''
+        end
+      end
+      expect { transaction.call }.to raise_exception(Minfraud::TransactionError, /required/)
+    end
+
+    it 'raises an exception if cvv_result is not a single letter' do
+      transaction = lambda do
+        Minfraud::Transaction.new do |t|
+          t.ip = '127.0.0.1'
+          t.txn_id = 'Order-1-1'
+          t.license_key = 'license_key'
+          t.cvv_result = 'AB'
+        end
+      end
+      expect { transaction.call }.to raise_exception(Minfraud::TransactionError, /single letter/)
+    end
+
   end
 
-  describe '#attributes' do
+  describe 'Minfraud::Transaction#attributes' do
     subject(:transaction) do
       Minfraud::Transaction.new do |t|
-        t.ip = 'ip'
+        t.ip = '127.0.0.1'
+        t.txn_id = 'Order-1-1'
+        t.license_key = 'test_license'
         t.city = 'city'
         t.state = 'state'
         t.postal = 'postal'
         t.country = 'country'
         t.email = 'hughjass@example.com'
-        t.txn_id = 'Order-1'
         t.requested_type = 'standard'
-        t.license_key = ''
+        t.shop_id = 'test_shop'
+      end
+    end
+
+    subject(:transaction_convert_case) do
+      Minfraud::Transaction.new do |t|
+        t.ip = '127.0.0.1'
+        t.txn_id = 'Order-1-1'
+        t.license_key = 'test_license'
+        t.email = 'HUGHjass@examPLE.COM'
+      end
+    end
+
+    subject(:transaction_shop_id_int) do
+      Minfraud::Transaction.new do |t|
+        t.ip = '127.0.0.1'
+        t.txn_id = 'Order-1-1'
+        t.license_key = 'test_license'
+        t.shop_id = 123456789
       end
     end
 
     it 'returns a hash of attributes' do
-      expect(transaction.attributes[:ip]).to eq('ip')
+      expect(transaction.attributes[:ip]).to eq('127.0.0.1')
+      expect(transaction.attributes[:txn_id]).to eq('Order-1-1')
+      expect(transaction.attributes[:license_key]).to eq('test_license')
       expect(transaction.attributes[:city]).to eq('city')
       expect(transaction.attributes[:state]).to eq('state')
       expect(transaction.attributes[:postal]).to eq('postal')
       expect(transaction.attributes[:country]).to eq('country')
     end
 
-    it 'derives email domain and an md5 hash of whole email from email attribute' do
+    it 'derives email domain and an MD5 hash of whole email from email attribute' do
       expect(transaction.attributes[:email_domain]).to eq('example.com')
       expect(transaction.attributes[:email_md5]).to eq('01ddb59d9bc1d1bfb3eb99a22578ce33')
     end
+
+    it 'converts the email to lowercase when calculating its MD5 hash' do
+      expect(transaction_convert_case.attributes[:email_domain]).to eq('examPLE.COM')
+      expect(transaction_convert_case.attributes[:email_md5]).to eq('01ddb59d9bc1d1bfb3eb99a22578ce33')
+    end
+
+    it 'converts the shop_id from int to string' do
+      expect(transaction_shop_id_int.attributes[:shop_id]).to eq('123456789')
+    end
+
   end
 
 end


### PR DESCRIPTION
To be merged into `master` along with changes in `switch_to_faraday`, leaving the `switch_to_faraday` branch since it is being referenced by production systems.

See corresponding BladeRunner PR: https://github.com/Shopify/BladeRunner/pull/2645

# Improve validation and refactor client

### What are you trying to accomplish?

Improve validation to add checks on all attributes, while updating documentation to reflect what is happening. This classifies the attributes into different categories:
- `INPUT_STRING_ATTRIBUTES` - Attributes must be strings
- `INPUT_NUMERIC_ATTRIBUTES` - Attributes must be numeric
- `REQUIRED_ATTRIBUTES` - Attributes must not be empty
- `CONVERT_STRING_ATTRIBUTES` - Attributes will be automatically converted to strings

Make `Transaction` and `Response` immutable after initialization.

Remove the `parse` step on a `Response` - this should be done when the `Response` is initialized.

Add check for `cvv_result` (should be a single letter) and downcase email before hashing (as specified by the Minfraud API).

Allow access to the response attribute Hash via `Response.body` (this returns a frozen Hash).

Allow optional block to be passed during `MinfraudClient.send_transaction` to modify the response Hash during initialization.

Sample usage (updated in the README):

```ruby
# Create a client to handle requests for a specific host
minfraud_client = Minfraud::MinfraudClient.new(
  # Optional fields to customize connection
  host_choice: 'us_east',
  open_timeout: 1,
  idle_timeout: 5,
  read_timeout: 5,
  write_timeout: 5,
  pool_size: 10
)

# Create a transaction with attributes to send
# The transaction will be immutable after creation
transaction = Minfraud::Transaction.new do |t|
  # Required fields
  t.ip = '1.2.3.4'
  t.txn_id = 'Order-1'
  t.license_key = 'minfraud-license-key'
  # Other fields are optional
  t.city = 'richmond'
  t.state = 'virginia'
  t.postal = '12345'
  t.country = 'US' # http://en.wikipedia.org/wiki/ISO_3166-1
  # ...
end

# Send the transaction to minFraud and retrieve the parsed response
# The response will be immutable
response = minfraud_client.send_transaction(
  transaction: transaction,
  # Optional url to customize the request endpoint
  # Default value is `/app/ccv2r`
  url: '/app/ccv2r'
)

# All attributes from minFraud's response will be available on the response object
# as a snake-cased attribute. For example, if you want the `proxyScore` field
# from minFraud, you can get it with `#proxy_score`.

response.risk_score
# => 3.48

response.queries_remaining
# => 1000

# A warning may be present in the `#err` attribute
response.err
# => nil

# The attributes can also be retrieved as a Hash
# Note that this is a frozen Hash
response_hash = response.body # frozen Hash
response_hash = response.body.dup # mutable duplicate of Hash

response[:risk_score]
response[:queries_remaining]
response[:err]
```

### Why did you choose this approach?

Followed type requirements in the [Minfraud Legacy API](https://dev.maxmind.com/minfraud/minfraud-legacy/), as well as what we're [currently passing in from core](https://github.com/Shopify/shopify/blob/d41b279f2c4a3c1b255c7d79bfeba0f38b451323/components/reviews/app/models/fraud_analysis/minfraud_analysis_attributes.rb#L11-L40).

Added `CONVERT_STRING_ATTRIBUTES` with `:shop_id` since we currently pass this as an integer, but Minfraud actually expects a string. This makes the typing of `:shop_id` more explicit.

Froze `Transaction` and `Response` after initialization to use them as immutable value objects.

### What should reviewers focus on?

Should converting the attributes in `CONVERT_STRING_ATTRIBUTES` happen in `validate_attributes` or should we do this more explicitly in another method?

### How are you going to verify this change?

Updated unit tests and tophatted as part of https://github.com/Shopify/BladeRunner/pull/2645.

# Switch to Faraday

### What are you trying to accomplish?

Switch to using [Faraday](https://github.com/lostisland/faraday) to make requests to MinFraud. This makes use of [Net::HTTP::Persistent](https://github.com/drbrain/net-http-persistent) to share connections in a connection pool. The goal is to increase the robustness of the client and as a bonus, speed up response times.

Added `Minfraud::MinfraudClient` as a way to send requests. The `send_transaction` method takes in a `Minfraud::Transaction` and returns a `Minfraud::Response`.

Removed configuration requirements for the `Minfraud` module.

Made `license_key` a required field on `Minfraud::Transaction`.

Updated version to `1.0.0`.

Sample usage (updated in the README):

```ruby
minfraud_client = Minfraud::MinfraudClient.new(
  # Optional fields to customize connection
  host_choice: 'us_east',
  open_timeout: 1,
  idle_timeout: 5,
  read_timeout: 5,
  write_timeout: 5,
  pool_size: 10
)

transaction = Minfraud::Transaction.new do |t|
  # Required fields
  # Other fields listed later in documentation are optional
  t.ip = '1.2.3.4'
  t.city = 'richmond'
  t.state = 'virginia'
  t.postal = '12345'
  t.country = 'US' # http://en.wikipedia.org/wiki/ISO_3166-1
  t.txn_id = 'Order-1'
  t.license_key = 'minfraud-license-key'
  # ...
end

response = minfraud_client.send_transaction(
  transaction: transaction,
  # Optional field to customize connection
  url: '/app/ccv2r'
)

response.parse # parses body to create hash

response.dig(:risk_score)
# => 3.48
```

### Why did you choose this approach?

This decouples the request logic from the `Minfraud::Transaction` object. This allows `Minfraud::Transaction`s to purely be containers for the data being passed around, and makes the flow simpler.

Removing the configuration step means that all connection customization will now come from the `Minfraud::MinfraudClient` and `Minfraud::Transaction` objects, making it more clear what's going on.

### What should reviewers focus on?

SSL verification was previously off. [As with the discussion here](https://github.com/Shopify/shopify/pull/255784/files#r466110438), I'm not sure if we should be bypassing verification. I opted to leave verification settings to Faraday defaults, which does have SSL verification.

### How are you going to verify this change?

Updated unit tests.

Tested locally and in staging by making requests in BladeRunner. More details on testing can be found in the [BladeRunner-side PR](https://github.com/Shopify/BladeRunner/pull/2623).

### Before you deploy

 - [x] [:tophat:](https://vault.shopify.com/developers/Tophatting)'d
 - [x] Safe to rollback?

@Shopify/riskeng

