### PR TITLE
Update API endpoint for MaxMind web services

### DIFF
--- a/spec/minfraud/minfraud_client_spec.rb
+++ b/spec/minfraud/minfraud_client_spec.rb
@@ -118,7 +118,7 @@ describe Minfraud::MinfraudClient do
   end
 
   def request_url_east
-    'https://minfraud-us-east.maxmind.com/app/ccv2r'
+    'https://minfraud.maxmind.com/app/ccv2r'
   end
 
 end


### PR DESCRIPTION
MaxMind is beginning to enforce policies around its API endpoints. Endpoints should use the correct hostname for the product or service, and should always use HTTPS.

[Release Note.](https://dev.maxmind.com/geoip/release-notes/2023#api-policies---temporary-enforcement-on-october-17-2023)